### PR TITLE
add types & predicates for sets

### DIFF
--- a/bdd.json
+++ b/bdd.json
@@ -29,6 +29,10 @@
         "TableVariation": { "@id": "bdd:TableVariation" },
         "rows": { "@id": "bdd:rows", "type": "@id", "@container": "@list" },
 
+        "Set": { "@id": "bdd:Set" },
+        "ConstantSet": { "@id": "bdd:Set" },
+        "elements": { "@id": "bdd:elements", "@container": "@set", "@type": "@id"  },
+
         "CartesianProductVariation": { "@id": "bdd:CartesianProductVariation" },
         "of-sets": { "@id": "bdd:of-sets", "type": "@id", "@container": "@list" },
 
@@ -36,7 +40,7 @@
         "Permutation": { "@id": "bdd:Permutation" },
         "repetition": { "@id": "bdd:repetition-allowed", "@type": "xsd:boolean" },
         "length": { "@id": "bdd:length", "@type": "xsd:positiveInteger" },
-        "from": { "@id": "bdd:from", "@container": "@list", "@type": "@id" },
+        "from": { "@id": "bdd:from", "@type": "@id" },
 
         "ForAll": { "@id": "bdd:ForAll" },
         "ThereExists": { "@id": "bdd:ThereExists" },

--- a/bdd.shacl.ttl
+++ b/bdd.shacl.ttl
@@ -60,6 +60,7 @@ bdd:HasClauseShape
 bdd:InSetShape
   a sh:PropertyShape ;
   sh:path bdd:in-set ;
+  sh:class bdd:Set ;
   sh:minCount 1 ;
   sh:maxCount 1 .
 
@@ -211,8 +212,16 @@ bdd:SceneHasAgentsShape
   ] .
 
 #######################################
-# Quantifier shape
+# Set & Quantifier shape
 #######################################
+bdd:ConstantSetShape
+  a sh:NodeShape ;
+  sh:targetClass bdd:ConstantSet ;
+  sh:property [
+    sh:path bdd:elements ;
+    sh:minCount 1 ;
+  ] .
+
 bdd:ForAllShape
   a sh:NodeShape ;
   sh:targetClass bdd:ForAll ;


### PR DESCRIPTION
- constant set (having `:Set` & `:ConstantSet` types) will have (a set of) `elements`
- a set variable (having `:Set` & `:ScenarioVariable` types) can be assigned sets of values
- `:Combination` will now point to a `:Set` model instead of specifying its own container
- update SHACL to reflect MM changes