### PR TITLE
Add Observation MM & Support Configuration Clause

### DIFF
--- a/bdd.json
+++ b/bdd.json
@@ -80,9 +80,6 @@
         "SimulatedExecution": { "@id": "bdd:SimulatedExecution" },
 
         "BehaviourImplementation": { "@id": "bdd:BehaviourImplementation" },
-        "has-behaviour-impl": { "@id": "bdd:has-behaviour-impl", "@type": "@id" },
-
-        "FluentImplementation": { "@id": "bdd:FluentImplementation" },
-        "has-fluent-impl": { "@id": "bdd:has-fluent-impl", "@type": "@id" }
+        "has-behaviour-impl": { "@id": "bdd:has-behaviour-impl", "@type": "@id" }
     }
 }

--- a/bdd.json
+++ b/bdd.json
@@ -57,6 +57,11 @@
         "IsHeldPredicate": { "@id": "bdd:IsHeldPredicate" },
         "MoveSafelyPredicate": { "@id": "bdd:MoveSafelyPredicate" },
         "SortedIntoPredicate": { "@id": "bdd:SortedIntoPredicate" },
+        "HasConfigPredicate": { "@id": "bdd:HasConfigPredicate" },
+
+        "config-target": { "@id": "bdd:config-target", "@type": "@id" },
+        "config-name": { "@id": "bdd:config-name", "@type": "xsd:string" },
+        "config-var": { "@id": "bdd:config-variable", "@type": "@id" },
 
         "ref-workspace": { "@id": "bdd:ref-workspace", "@type": "@id" },
         "ref-object": { "@id": "bdd:ref-object", "@type": "@id" },

--- a/observation.json
+++ b/observation.json
@@ -1,0 +1,20 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "obs": "https://secorolab.github.io/metamodels/observation#",
+        "ros": "https://index.ros.org/p/",
+
+        "ObservationProvider": { "@id": "obs:ObservationProvider" },
+
+
+        "ObservationPolicy": { "@id": "obs:ObservationPolicy" },
+        "provider": {"@id": "obs:has-provider", "@type": "@id"},
+
+        "ROSTopic": { "@id": "ros:ROSTopic" },
+        "topic-name": { "@id": "ros:topic-name", "@type": "xsd:string" },
+        "message-type": { "@id": "ros:message-type", "@type": "xsd:string" },
+
+        "HasFrameId": { "@id": "ros:HasFrameId" },
+        "frame-id": { "@id": "ros:frame-id", "@type": "xsd:string" }
+    }
+}

--- a/time.json
+++ b/time.json
@@ -1,5 +1,6 @@
 {
     "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
         "time": "https://secorolab.github.io/metamodels/time#",
         "Event": { "@id": "time:Event" },
 
@@ -10,6 +11,7 @@
         "AfterEventConstraint": { "@id": "time:AfterEventConstraint" },
         "DuringEventsConstraint": { "@id": "time:DuringEventsConstraint" },
         "before-event": { "@id": "time:before-event", "@type": "@id" },
-        "after-event": { "@id": "time:after-event", "@type": "@id" }
+        "after-event": { "@id": "time:after-event", "@type": "@id" },
+        "horizon-seconds": { "@id": "time:horizon-seconds", "@type": "@xsd:float" }
     }
 }

--- a/time.json
+++ b/time.json
@@ -12,6 +12,6 @@
         "DuringEventsConstraint": { "@id": "time:DuringEventsConstraint" },
         "before-event": { "@id": "time:before-event", "@type": "@id" },
         "after-event": { "@id": "time:after-event", "@type": "@id" },
-        "horizon-seconds": { "@id": "time:horizon-seconds", "@type": "@xsd:float" }
+        "horizon-seconds": { "@id": "time:horizon-seconds", "@type": "xsd:float" }
     }
 }


### PR DESCRIPTION
This PR introduces an initial observation metamodel for specifying the link between the System under Test (SuT) and fluent clauses, i.e., specifying how the SuT provide evidence for asserting fluent(s) in a scenario.

* In the initial setup, the SuT will provide the test process with trinary values directly, i.e., true, false, unknown, for requested fluents. The ROS concepts to support specification of the message type and topic. In the future, BDD specification should also include explicitly the resolution from observations, e.g., object poses, to the trinary value.
* Example models for this will be introduced in minhnh/models-bdd#4, model parsing will be introduced in minhnh/bdd-dsl#34, and execution setup with ROS2 is available in the [minhnh/bdd_exec_ros2](https://github.com/minhnh/bdd_exec_ros2) repo.

Additionally, the PR also includes the following changes to existing MM:

* Addition of the `horizon` concept for managing time windows of `BeforeEvent` and `AfterEvent` time constraints. This is necessary/desirable in the time resolution implementation, so that the time window won't grow indefinitely.
* Support for `HasConfigPredicate` for specifying configurations of scene elements, e.g., movement speed of a robot. Both the config target (robot) and configuration (speed) can map to variables, i.e., can change in scenario variations.