### PR TITLE
add metamodel for StringTemplatePredicate

### DIFF
--- a/bdd.json
+++ b/bdd.json
@@ -57,8 +57,13 @@
         "IsHeldPredicate": { "@id": "bdd:IsHeldPredicate" },
         "MoveSafelyPredicate": { "@id": "bdd:MoveSafelyPredicate" },
         "SortedIntoPredicate": { "@id": "bdd:SortedIntoPredicate" },
-        "HasConfigPredicate": { "@id": "bdd:HasConfigPredicate" },
 
+        "StringTemplatePredicate": { "@id": "bdd:StringTemplatePredicate" },
+        "tmpl-str": { "@id": "bdd:template-string", "@type": "xsd:string" },
+        "arg-names": { "@id": "bdd:argument-names", "@type": "xsd:string", "@container": "@list" },
+        "arg-variables": { "@id": "bdd:argument-variables", "@type": "@id", "@container": "@list" },
+
+        "HasConfigPredicate": { "@id": "bdd:HasConfigPredicate" },
         "config-target": { "@id": "bdd:config-target", "@type": "@id" },
         "config-name": { "@id": "bdd:config-name", "@type": "xsd:string" },
         "config-var": { "@id": "bdd:config-variable", "@type": "@id" },

--- a/bdd.shacl.ttl
+++ b/bdd.shacl.ttl
@@ -159,6 +159,26 @@ bdd:WhenBehaviourShape
     [ sh:class time:TimeConstraint ]
   ) .
 
+bdd:StringTemplatePredicateShape
+  a sh:NodeShape ;
+  sh:targetClass bdd:StringTemplatePredicate ;
+  sh:property [
+    sh:path bdd:template-string ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path bdd:argument-names ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path bdd:argument-variables ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
 #######################################
 # ScenarioTemplate shape
 #######################################


### PR DESCRIPTION
This allows specifying generic string clauses, where '{...}' arguments are linked to ScenarioVariable IRIs, which will be replaced based on variation specification.

* 'template-string' attr containing '{...}' arguments to be be replaced
* 'argument-names' attr containing a list of string arguments
* 'argument-variables' attr containing a list of variable IRIs