### PR TITLE
Reify ObservationPolicy to separate models from FluentClause

### DIFF
--- a/bdd.json
+++ b/bdd.json
@@ -48,6 +48,7 @@
 
         "FluentClause": { "@id": "bdd:FluentClause" },
         "clause-of": { "@id": "bdd:clause-of", "@type": "@id" },
+        "of-clause": { "@id": "bdd:of-clause", "@type": "@id" },
         "has-clause": {
             "@id": "bdd:has-clause", "@container": "@list", "@type": "@id"
         },
@@ -90,6 +91,6 @@
         "SimulatedExecution": { "@id": "bdd:SimulatedExecution" },
 
         "BehaviourImplementation": { "@id": "bdd:BehaviourImplementation" },
-        "has-behaviour-impl": { "@id": "bdd:has-behaviour-impl", "@type": "@id" }
+        "has-behaviour-impl": { "@id": "bdd:has-behaviour-implementation", "@type": "@id" }
     }
 }

--- a/observation.json
+++ b/observation.json
@@ -2,19 +2,11 @@
     "@context": {
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "obs": "https://secorolab.github.io/metamodels/observation#",
-        "ros": "https://index.ros.org/p/",
 
         "ObservationProvider": { "@id": "obs:ObservationProvider" },
-
+        "has-provider": {"@id": "obs:has-provider", "@type": "@id"},
 
         "ObservationPolicy": { "@id": "obs:ObservationPolicy" },
-        "provider": {"@id": "obs:has-provider", "@type": "@id"},
-
-        "ROSTopic": { "@id": "ros:ROSTopic" },
-        "topic-name": { "@id": "ros:topic-name", "@type": "xsd:string" },
-        "message-type": { "@id": "ros:message-type", "@type": "xsd:string" },
-
-        "HasFrameId": { "@id": "ros:HasFrameId" },
-        "frame-id": { "@id": "ros:frame-id", "@type": "xsd:string" }
+        "has-policy": {"@id": "obs:has-policy", "@type": "@id"}
     }
 }

--- a/ros.json
+++ b/ros.json
@@ -1,5 +1,6 @@
 {
     "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
         "ros": "https://index.ros.org/p/",
         "ROSTopic": { "@id": "ros:Topic" },
         "ROSAction": { "@id": "ros:Action" },

--- a/ros.json
+++ b/ros.json
@@ -1,0 +1,14 @@
+{
+    "@context": {
+        "ros": "https://index.ros.org/p/",
+        "ROSTopic": { "@id": "ros:Topic" },
+        "ROSAction": { "@id": "ros:Action" },
+        "ROSService": { "@id": "ros:Service" },
+
+        "channel-name": { "@id": "ros:channel-name", "@type": "xsd:string" },
+        "type-name": { "@id": "ros:type-name", "@type": "xsd:string" },
+
+        "HasFrameId": { "@id": "ros:HasFrameId" },
+        "frame-id": { "@id": "ros:frame-id", "@type": "xsd:string" }
+    }
+}


### PR DESCRIPTION
- To support selecting specifc policies for different scenario execution, and potentially having multiple policies for each FluentClause, the following relations are added:
  + `bdd:of-clause` link ObservationPolicy to FluentClause
  + `obs:has-policy` link ScenarioExecution to ObservationPolicy
- Move ROS concepts to a separate context.